### PR TITLE
Simplify the observer

### DIFF
--- a/.changeset/polite-wolves-cheat.md
+++ b/.changeset/polite-wolves-cheat.md
@@ -1,0 +1,5 @@
+---
+"@hirasso/thumbhash-custom-element": patch
+---
+
+Simplify the observer

--- a/src/support/observer.ts
+++ b/src/support/observer.ts
@@ -1,7 +1,5 @@
 import type { ThumbHashElement } from "../index.js";
 
-const observedElements = new WeakSet<ThumbHashElement>();
-
 let observer: IntersectionObserver | undefined;
 
 /** Render if intersecting */
@@ -23,24 +21,15 @@ export function observe(element: ThumbHashElement) {
     return;
   }
 
-  /** Bail early if already observing */
-  if (observedElements.has(element)) {
-    return;
-  }
-
   /** Make sure only one IntersectionObserver exists */
   observer ??= new IntersectionObserver(callback, {
     rootMargin: "100% 100% 100% 100%",
   });
 
   observer.observe(element);
-  observedElements.add(element);
 }
 
 /** Unobserve an element */
 export function unobserve(element: ThumbHashElement) {
-  if (!observedElements.has(element)) return;
-
   observer?.unobserve(element);
-  observedElements.delete(element);
 }


### PR DESCRIPTION
Calling `observer.observe(el)` twice on the same element doesn't create two `IntersectionObserverEntries`. So no need for manually tracking observed elements

<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (bug fix, feature, chore) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to the library.
-->

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was formatted before pushing (`npm run format`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
