### PR TITLE
chore: optimize tooling

### DIFF
--- a/.changeset/curvy-moles-care.md
+++ b/.changeset/curvy-moles-care.md
@@ -1,0 +1,5 @@
+---
+"@hirasso/thumbhash-custom-element": patch
+---
+
+Use `devEngines.packageManager` instead of `npx only-allow pnpm` for enforcing `pnpm` as a the manager

--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dist"
   ],
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf ./dist",
     "format": "pnpm exec prettier 'src/**/*.{js,ts,mjs}' --write",
     "prepublishOnly": "pnpm build",
@@ -71,5 +70,11 @@
     "sharp": "^0.33.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
**Description**

- add `pull-requests: write` to the version-or-publish workflow permissions
- Use `devEngines.packageManager` instead of `npx only-allow pnpm` for enforcing `pnpm` as a the manager

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was formatted before pushing (`npm run format`)